### PR TITLE
Remove deprecated register keyword to make compatible with C++17

### DIFF
--- a/src/libtreeler/treeler/base/feature-idx-v0.h
+++ b/src/libtreeler/treeler/base/feature-idx-v0.h
@@ -68,11 +68,11 @@ namespace treeler {
   public:
     inline size_t operator()(const FeatureIdx& t) const {
       /* grab low-order bits */
-      register uint32_t a = (uint32_t)(t & 0xffffffff);
+      auto uint32_t a = (uint32_t)(t & 0xffffffff);
       /* grab high-order bits */
-      register uint32_t b = (uint32_t)((t >> 32) & 0xffffffff);
+      auto uint32_t b = (uint32_t)((t >> 32) & 0xffffffff);
       /* nothing to grab */
-      register uint32_t c = 0;
+      auto uint32_t c = 0;
 
 #define rot(x, k) ((x << k) | (x >> (32 - k)))
 


### PR DESCRIPTION
C++17 will not compile if it sees the `register` keyword ([with which the compiler didn't do much anyhow](https://stackoverflow.com/a/20618056)). This replaces `register` with `auto`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jslauthor/freeling/1)
<!-- Reviewable:end -->
